### PR TITLE
Update test context usages

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,5 @@
 import unittest
 
-from flask import url_for
-
 from bluelog import create_app
 from bluelog.extensions import db
 from bluelog.models import Admin
@@ -10,11 +8,11 @@ from bluelog.models import Admin
 class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
-        app = create_app('testing')
-        self.context = app.test_request_context()
+        self.app = create_app('testing')
+        self.context = self.app.app_context()
         self.context.push()
-        self.client = app.test_client()
-        self.runner = app.test_cli_runner()
+        self.client = self.app.test_client()
+        self.cli_runner = self.app.test_cli_runner()
 
         db.create_all()
         user = Admin(name='Grey Li', username='grey', about='I am test', blog_title='Testlog', blog_sub_title='a test')
@@ -31,10 +29,10 @@ class BaseTestCase(unittest.TestCase):
             username = 'grey'
             password = '123'
 
-        return self.client.post(url_for('auth.login'), data=dict(
+        return self.client.post('/auth/login', data=dict(
             username=username,
             password=password
         ), follow_redirects=True)
 
     def logout(self):
-        return self.client.get(url_for('auth.logout'), follow_redirects=True)
+        return self.client.get('/auth/logout', follow_redirects=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,3 @@
-from flask import url_for
-
 from tests.base import BaseTestCase
 
 
@@ -22,6 +20,6 @@ class AuthTestCase(BaseTestCase):
         self.assertIn('Logout success.', data)
 
     def test_login_protect(self):
-        response = self.client.get(url_for('admin.settings'), follow_redirects=True)
+        response = self.client.get('/admin/settings', follow_redirects=True)
         data = response.get_data(as_text=True)
         self.assertIn('Please log in to access this page.', data)

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1,5 +1,3 @@
-from flask import url_for
-
 from bluelog.models import Post, Category, Link, Comment
 from bluelog.extensions import db
 
@@ -30,36 +28,36 @@ class BlogTestCase(BaseTestCase):
         self.assertIn('GitHub', data)
 
     def test_post_page(self):
-        response = self.client.get(url_for('blog.show_post', post_id=1))
+        response = self.client.get('/post/1')
         data = response.get_data(as_text=True)
         self.assertIn('Hello Post', data)
         self.assertIn('A comment', data)
 
     def test_change_theme(self):
-        response = self.client.get(url_for('blog.change_theme', theme_name='perfect_blue'), follow_redirects=True)
+        response = self.client.get('/change-theme/perfect_blue', follow_redirects=True)
         data = response.get_data(as_text=True)
         self.assertIn('css/perfect_blue.min.css', data)
         self.assertNotIn('css/black_swan.min.css', data)
 
-        response = self.client.get(url_for('blog.change_theme', theme_name='black_swan'), follow_redirects=True)
+        response = self.client.get('/change-theme/black_swan', follow_redirects=True)
         data = response.get_data(as_text=True)
         self.assertIn('css/black_swan.min.css', data)
         self.assertNotIn('css/perfect_blue.min.css', data)
 
     def test_about_page(self):
-        response = self.client.get(url_for('blog.about'))
+        response = self.client.get('/about')
         data = response.get_data(as_text=True)
         self.assertIn('I am test', data)
         self.assertIn('About', data)
 
     def test_category_page(self):
-        response = self.client.get(url_for('blog.show_category', category_id=1))
+        response = self.client.get('/category/1')
         data = response.get_data(as_text=True)
         self.assertIn('Category: Default', data)
         self.assertIn('Hello Post', data)
 
     def test_new_admin_comment(self):
-        response = self.client.post(url_for('blog.show_post', post_id=1), data=dict(
+        response = self.client.post('/post/1', data=dict(
             body='I am an admin comment.',
             post=Post.query.get(1),
         ), follow_redirects=True)
@@ -69,7 +67,7 @@ class BlogTestCase(BaseTestCase):
 
     def test_new_guest_comment(self):
         self.logout()
-        response = self.client.post(url_for('blog.show_post', post_id=1), data=dict(
+        response = self.client.post('/post/1', data=dict(
             author='Guest',
             email='a@b.com',
             site='http://greyli.com',
@@ -81,7 +79,7 @@ class BlogTestCase(BaseTestCase):
         self.assertNotIn('I am a guest comment.', data)
 
     def test_reply_status(self):
-        response = self.client.get(url_for('blog.reply_comment', comment_id=1), follow_redirects=True)
+        response = self.client.get('/reply/comment/1', follow_redirects=True)
         data = response.get_data(as_text=True)
         self.assertIn('Reply to', data)
         self.assertIn('Cancel', data)
@@ -90,14 +88,14 @@ class BlogTestCase(BaseTestCase):
         post.can_comment = False
         db.session.commit()
 
-        response = self.client.get(url_for('blog.reply_comment', comment_id=1), follow_redirects=True)
+        response = self.client.get('/reply/comment/1', follow_redirects=True)
         data = response.get_data(as_text=True)
         self.assertIn('Comment is disabled.', data)
         self.assertNotIn('Reply to', data)
         self.assertNotIn('Cancel', data)
 
     def test_new_admin_reply(self):
-        response = self.client.post(url_for('blog.show_post', post_id=1) + '?reply=1', data=dict(
+        response = self.client.post('/post/1' + '?reply=1', data=dict(
             body='I am an admin reply comment.',
             post=Post.query.get(1),
         ), follow_redirects=True)
@@ -108,7 +106,7 @@ class BlogTestCase(BaseTestCase):
 
     def test_new_guest_reply(self):
         self.logout()
-        response = self.client.post(url_for('blog.show_post', post_id=1) + '?reply=1', data=dict(
+        response = self.client.post('/post/1' + '?reply=1', data=dict(
             author='Guest',
             email='a@b.com',
             site='http://greyli.com',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,16 +10,16 @@ class CLITestCase(BaseTestCase):
         db.drop_all()
 
     def test_initdb_command(self):
-        result = self.runner.invoke(args=['initdb'])
+        result = self.cli_runner.invoke(args=['initdb'])
         self.assertIn('Initialized database.', result.output)
 
     def test_initdb_command_with_drop(self):
-        result = self.runner.invoke(args=['initdb', '--drop'], input='y\n')
+        result = self.cli_runner.invoke(args=['initdb', '--drop'], input='y\n')
         self.assertIn('This operation will delete the database, do you want to continue?', result.output)
         self.assertIn('Drop tables.', result.output)
 
     def test_init_command(self):
-        result = self.runner.invoke(args=['init', '--username', 'grey', '--password', '123'])
+        result = self.cli_runner.invoke(args=['init', '--username', 'grey', '--password', '123'])
         self.assertIn('Creating the temporary administrator account...', result.output)
         self.assertIn('Creating the default category...', result.output)
         self.assertIn('Done.', result.output)
@@ -28,8 +28,8 @@ class CLITestCase(BaseTestCase):
         self.assertEqual(Category.query.first().name, 'Default')
 
     def test_init_command_with_update(self):
-        self.runner.invoke(args=['init', '--username', 'grey', '--password', '123'])
-        result = self.runner.invoke(args=['init', '--username', 'new grey', '--password', '123'])
+        self.cli_runner.invoke(args=['init', '--username', 'grey', '--password', '123'])
+        result = self.cli_runner.invoke(args=['init', '--username', 'new grey', '--password', '123'])
         self.assertIn('The administrator already exists, updating...', result.output)
         self.assertNotIn('Creating the temporary administrator account...', result.output)
         self.assertEqual(Admin.query.count(), 1)
@@ -37,7 +37,7 @@ class CLITestCase(BaseTestCase):
         self.assertEqual(Category.query.first().name, 'Default')
 
     def test_forge_command(self):
-        result = self.runner.invoke(args=['forge'])
+        result = self.cli_runner.invoke(args=['forge'])
 
         self.assertEqual(Admin.query.count(), 1)
         self.assertIn('Generating the administrator...', result.output)
@@ -55,7 +55,7 @@ class CLITestCase(BaseTestCase):
         self.assertIn('Done.', result.output)
 
     def test_forge_command_with_count(self):
-        result = self.runner.invoke(args=['forge', '--category', '5', '--post', '20', '--comment', '100'])
+        result = self.cli_runner.invoke(args=['forge', '--category', '5', '--post', '20', '--comment', '100'])
         self.assertEqual(Admin.query.count(), 1)
         self.assertIn('Generating the administrator...', result.output)
 


### PR DESCRIPTION
- Push app context instead of the request context.
- Update `url_for` calls with hard-coded URLs.